### PR TITLE
feat(hardhat-forge): update key ordering of hh artifact

### DIFF
--- a/.changeset/silly-pigs-wonder.md
+++ b/.changeset/silly-pigs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Update artifact so that JSON will be ordered the same way that hh orders the keys

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -57,14 +57,14 @@ export class ForgeArtifacts implements IArtifacts {
   ): Artifact {
     const { abi, bytecode, deployedBytecode } = artifact;
     const hhArtifact = {
+      _format: ARTIFACT_FORMAT_VERSION,
+      contractName: name,
+      sourceName: this._getFullyQualifiedNameFromPath(artifactPath),
       abi,
       bytecode: bytecode.object,
-      contractName: name,
       deployedBytecode: deployedBytecode.object,
-      deployedLinkReferences: bytecode.linkReferences,
       linkReferences: deployedBytecode.linkReferences,
-      sourceName: this._getFullyQualifiedNameFromPath(artifactPath),
-      _format: ARTIFACT_FORMAT_VERSION,
+      deployedLinkReferences: bytecode.linkReferences,
     };
     return hhArtifact as Artifact;
   }


### PR DESCRIPTION
When turning a JS object into a JSON string, the order
of the keys will dictate the order of the keys in
the JSON. This change matches the format that hardhat
uses when writing the JSON artifacts to disk.

The format used by hardhat is shown below.

```
[
  "_format",
  "abi",
  "bytecode",
  "contractName",
  "deployedBytecode",
  "deployedLinkReferences",
  "linkReferences",
  "sourceName"
]
```