### PR TITLE
feat: write hardhat style artifacts to disk

### DIFF
--- a/.changeset/strong-cheetahs-call.md
+++ b/.changeset/strong-cheetahs-call.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Write hh style artifacts to disk

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -20,6 +20,15 @@ extendEnvironment((hre) => {
       config.cache_path ?? "cache",
       SOLIDITY_FILES_CACHE_FILENAME
     );
-    return new ForgeArtifacts(outDir, cacheDir);
+
+    const artifacts = new ForgeArtifacts(
+      hre.config.paths.root,
+      config.src,
+      outDir,
+      cacheDir
+    );
+
+    artifacts.writeArtifactsSync(hre.config.paths.artifacts);
+    return artifacts;
   });
 });

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/foo/Contract2.sol
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/foo/Contract2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract FooBar {
+
+  function example() public {}
+
+}

--- a/packages/hardhat-forge/test/helpers.ts
+++ b/packages/hardhat-forge/test/helpers.ts
@@ -1,5 +1,7 @@
 import { resetHardhatContext } from "hardhat/plugins-testing";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import fsExtra from "fs-extra";
+
 import path from "path";
 
 declare module "mocha" {
@@ -18,4 +20,18 @@ export function useEnvironment(fixtureProjectName: string) {
   afterEach("Resetting hardhat", function () {
     resetHardhatContext();
   });
+}
+
+export async function getAllFiles(directory: string, files: string[] = []) {
+  const current = await fsExtra.readdir(directory);
+  for (const file of current) {
+    const next = path.join(directory, file);
+    const info = await fsExtra.stat(next);
+    if (info.isDirectory()) {
+      files = await getAllFiles(next, files);
+    } else {
+      files.push(next);
+    }
+  }
+  return files;
 }

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "chai";
-import { useEnvironment } from "./helpers";
+import path from "path";
+import { useEnvironment, getAllFiles } from "./helpers";
 
 describe("Integration tests", function () {
   this.timeout(300000);
@@ -33,6 +34,19 @@ describe("Integration tests", function () {
       assert.exists(contract.deployedLinkReferences);
       assert.exists(contract.contractName);
       assert.exists(contract.sourceName);
+    });
+
+    it("Should write artifacts to disk", async function () {
+      const artifacts = await this.hre.artifacts.getArtifactPaths();
+      const files = await getAllFiles(this.hre.config.paths.artifacts);
+      assert.equal(artifacts.length, files.length);
+
+      for (const file of files) {
+        const name = path.basename(file);
+        assert(artifacts.map((a) => path.basename(a)).includes(name));
+        const artifact = require(file);
+        assert.equal(artifact.contractName, path.basename(name, ".json"));
+      }
     });
   });
 });


### PR DESCRIPTION
This will now write hardhat style artifacts to disk after running `hardhat compile`.

An example of how hardhat does this:

```
artifacts/
├── build-info
├── contracts
│   ├── chugsplash
│   ├── L1
│   ├── L2
│   ├── libraries
│   ├── standards
└── @openzeppelin
    ├── contracts
    └── contracts-upgradeable
```
The layout of the artifacts mirrors the layout of the contract source, unlike `foundry` which flattens all of the artifacts into a single top level directory

As of this PR, `artifacts/build-info` is not populated. I do not believe deps are compiled either unless they are used (the openzeppelin contracts in this example), hh seems to always compile them.

I do think that having the functionality to build hardhat style artifacts would be more suited for `ethers-rs` as the relative path to the source file is lost without looking at the forge artifact `.ast.absolutePath` (and having latest forge with https://github.com/gakonst/ethers-rs/commit/54f1b9dee8f2317f0805ea5021f3d38a6118a459 ?).

This errors if 2 contracts have the same name, see: https://github.com/foundry-rs/hardhat/blob/736941e266c22e7db6c95a379d1ec2f8cb2e0347/packages/hardhat-forge/src/forge/artifacts.ts#L419

This is very helpful for making things just work with `hardhat deploy` and `hardhat tasks`.

A few thoughts on the design:
- A config option to choose to write the files to disk or not? Unclear where in the hardhat config that would live, something like `.forge.writeArtifacts`? and default it to true?
- Write the files to disk in the constructor instead of after constructing the `ForgeArtifacts`?

Right now in a project I am using an alternative and very hacky method to write the hh artifacts to disk and have confirmed that with having them written to disk, `hardhat deploy` works with `anvil`