### PR TITLE
feat: allow other plugins to be composed with `build`

### DIFF
--- a/.changeset/fuzzy-cougars-drive.md
+++ b/.changeset/fuzzy-cougars-drive.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Enable downstream plugins to work with compile

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -30,7 +30,6 @@ import { ForgeArtifact } from "./types";
 export class ForgeArtifacts implements IArtifacts {
   constructor(
     private _root: string,
-    private _sources: string,
     private _out: string,
     private _cache: string
   ) {}
@@ -48,6 +47,18 @@ export class ForgeArtifacts implements IArtifacts {
     const forgeArtifact = fsExtra.readJsonSync(artifactPath) as ForgeArtifact;
     return this.convertForgeArtifact(forgeArtifact, artifactPath, name);
   }
+
+  /**
+   * Noop so that runSuper can be called
+   */
+  public addValidArtifacts(
+    _validArtifacts: Array<{ sourceName: string; artifacts: string[] }>
+  ) {}
+
+  /**
+   * Noop so that runSuper can be called
+   */
+  public async removeObsoleteArtifacts() {}
 
   /**
    * Converts a forge artifact to a hardhat style `Artifact`

--- a/packages/hardhat-forge/src/forge/build/index.ts
+++ b/packages/hardhat-forge/src/forge/build/index.ts
@@ -14,9 +14,10 @@ registerProjectPathArgs(registerCompilerArgs(task("compile")))
     "viaIr",
     "Use the Yul intermediate representation compilation pipeline."
   )
-  .setAction(async (args, {}) => {
+  .setAction(async (args, {}, runSuper) => {
     const buildArgs = await getCheckedArgs(args);
     await spawnBuild(buildArgs);
+    await runSuper(args);
   });
 
 async function getCheckedArgs(args: any): Promise<ForgeBuildArgs> {

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -23,7 +23,6 @@ extendEnvironment((hre) => {
 
     const artifacts = new ForgeArtifacts(
       hre.config.paths.root,
-      config.src,
       outDir,
       cacheDir
     );


### PR DESCRIPTION
Call `runSuper` after compiling so that other plugins that hook into the `compile` task are still called.
I discovered that `hardhat/typechain` was not being ran with this plugin and I believe that this is the solution.
Need to test locally to be sure. Note that calling `runSuper` here does not invoke the hardhat compiler
toolchain. Two additional functions are added that I believe should be part of the `IArtifacts` interface but are not.
Both of them are noops here, attempting to implement them would require a much larger change. Without them,
there is a `function is not defined` error.

Also delete some dead code in the constructor of `ForgeArtifacts`
