### PR TITLE
fix: ts build ordering

### DIFF
--- a/.changeset/neat-planes-peel.md
+++ b/.changeset/neat-planes-peel.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat": patch
+---
+
+Fix build ordering

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "wsrun": "^5.2.2"
     },
     "scripts": {
-        "build": "tsc --build packages/hardhat packages/easy-foundryup packages/hardhat-anvil packages/hardhat-forge",
-        "watch": "tsc --build --watch packages/hardhat packages/easy-foundryup packages/hardhat-anvil packages/hardhat-forge",
+        "build": "tsc --build packages/hardhat-forge packages/hardhat-anvil packages/hardhat packages/easy-foundryup",
+        "watch": "tsc --build --watch packages/hardhat-anvil packages/hardhat-forgepackages/hardhat packages/easy-foundryup",
         "clean": "wsrun --exclude-missing clean",
         "test": "wsrun --exclude-missing test",
         "lint": "wsrun --exclude-missing --stages lint && yarn prettier --check",


### PR DESCRIPTION
Since `packages/hardhat` depends on `packages/hardhat-anvil`
and `packages/hardhat-forge`, they must be built first.
If they are not, building `packages/hardhat` will fail
being unable to locate the other packages.

See https://github.com/foundry-rs/hardhat/runs/6651154556?check_suite_focus=true

```
Error: packages/hardhat/src/index.ts(1,24): error TS2307: Cannot find module '@foundry-rs/hardhat-forge' or its corresponding type declarations.
Error: packages/hardhat/src/index.ts(2,24): error TS2307: Cannot find module '@foundry-rs/hardhat-anvil' or its corresponding type declarations.
```