### PR TITLE
fix(hh/forge): typechain support (#45)

### DIFF
--- a/.changeset/many-rivers-jump.md
+++ b/.changeset/many-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add deprecated private method for typechain compat

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -251,6 +251,19 @@ export class ForgeArtifacts implements IArtifacts {
     return artifactPath;
   }
 
+  /**
+   * DO NOT DELETE OR CHANGE
+   *
+   * use this.formArtifactPathFromFullyQualifiedName instead
+   * @deprecated until typechain migrates to public version
+   * @see https://github.com/dethcrypto/TypeChain/issues/544
+   */
+  private _getArtifactPathFromFullyQualifiedName(
+    fullyQualifiedName: string
+  ): string {
+    return this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
+  }
+
   private _getAllContractNamesFromFiles(files: string[]): string[] {
     return files.map((file) => {
       const fqn = this._getFullyQualifiedNameFromPath(file);


### PR DESCRIPTION
Typechain uses a private method on the artifact
with an unsafe `any` typecast to get artifact paths.
To work with typechain, this method must exist until
typechain is updated.

The issue is here: https://github.com/dethcrypto/TypeChain/issues/544