### PR TITLE
feat: `Artifacts.getBuildInfo`

### DIFF
--- a/.changeset/tame-otters-sing.md
+++ b/.changeset/tame-otters-sing.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Implement `Artifacts.getBuildInfo`

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
@@ -3,4 +3,6 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 
+extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/Contract.sol
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/Contract.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 contract Contract {
-
-  function example() public {}
-  
+    uint256 public bar;
+    function example() public {}
 }

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -48,5 +48,22 @@ describe("Integration tests", function () {
         assert.equal(artifact.contractName, path.basename(name, ".json"));
       }
     });
+
+    it("Should return build info", async function () {
+      const info = await this.hre.artifacts.getBuildInfo("Contract");
+      assert.exists(info);
+      const contract = info?.output.contracts["src/Contract.sol"].Contract!;
+      assert.exists(contract);
+      assert.exists(contract.abi);
+      assert.exists((contract as any).devdoc);
+      assert.exists((contract as any).metadata);
+      assert.exists((contract as any).storageLayout);
+      assert.exists((contract as any).userdoc);
+      assert.exists(contract.evm);
+      assert.exists(contract.evm.bytecode);
+      assert.exists(contract.evm.bytecode.object);
+      assert.exists(contract.evm.deployedBytecode);
+      assert.exists(contract.evm.deployedBytecode.object);
+    });
   });
 });


### PR DESCRIPTION
Implement a naive `getBuildInfo` function. This is useful
for tooling that integrates more deeply with the hardhat ecosystem.
Note that this implementation is not 100% with the output
that the hardhat compiler toolchain outputs, but the output
is good enough to get more tooling to be compatible.