### PR TITLE
hardhat-forge: use the correct source name

### DIFF
--- a/.changeset/nine-ads-melt.md
+++ b/.changeset/nine-ads-melt.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Use the correct source name in the artifact

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -39,13 +39,13 @@ export class ForgeArtifacts implements IArtifacts {
     const forgeArtifact = (await fsExtra.readJson(
       artifactPath
     )) as ForgeArtifact;
-    return this.convertForgeArtifact(forgeArtifact, artifactPath, name);
+    return this.convertForgeArtifact(forgeArtifact, name);
   }
 
   public readArtifactSync(name: string): Artifact {
     const artifactPath = this._getArtifactPathSync(name);
     const forgeArtifact = fsExtra.readJsonSync(artifactPath) as ForgeArtifact;
-    return this.convertForgeArtifact(forgeArtifact, artifactPath, name);
+    return this.convertForgeArtifact(forgeArtifact, name);
   }
 
   /**
@@ -66,16 +66,17 @@ export class ForgeArtifacts implements IArtifacts {
    * @param artifactPath
    * @param name
    */
-  public convertForgeArtifact(
-    artifact: ForgeArtifact,
-    artifactPath: string,
-    name: string
-  ): Artifact {
+  public convertForgeArtifact(artifact: ForgeArtifact, name: string): Artifact {
     const { abi, bytecode, deployedBytecode } = artifact;
+
+    if (!artifact.ast) {
+      throw new Error("Must compile with ast");
+    }
+
     const hhArtifact = {
       _format: ARTIFACT_FORMAT_VERSION,
       contractName: name,
-      sourceName: this._getFullyQualifiedNameFromPath(artifactPath),
+      sourceName: artifact.ast.absolutePath,
       abi,
       bytecode: bytecode.object,
       deployedBytecode: deployedBytecode.object,

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -25,6 +25,7 @@ describe("Integration tests", function () {
       const artifacts = await this.hre.artifacts.getArtifactPaths();
       assert.isNotEmpty(artifacts);
       const contract = await this.hre.artifacts.readArtifact("Contract");
+      assert.equal(contract.sourceName, "src/Contract.sol");
       assert.exists(contract.abi);
       assert.exists(contract.bytecode);
       assert.typeOf(contract.bytecode, "string");


### PR DESCRIPTION
The relative path to the file from the root
of the project should be used as the source name
in the artifact.

Closes https://github.com/foundry-rs/hardhat/issues/36

This will fix tooling that depends on the source name:
https://github.com/defi-wonderland/smock/blob/27fe7a5f3c351714257cdc98204e282932c11e12/src/utils/storage.ts#L54