### PR TITLE
test: explicitly set port for anvil

### DIFF
--- a/.changeset/strange-rice-decide.md
+++ b/.changeset/strange-rice-decide.md
@@ -1,0 +1,6 @@
+---
+"@foundry-rs/hardhat": patch
+"@foundry-rs/hardhat-anvil": patch
+---
+
+fix flaky tests

--- a/packages/hardhat-anvil/test/helpers.ts
+++ b/packages/hardhat-anvil/test/helpers.ts
@@ -1,6 +1,8 @@
 import { resetHardhatContext } from "hardhat/plugins-testing";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
+import net from "net";
+
 declare module "mocha" {
   interface Context {
     env: HardhatRuntimeEnvironment;
@@ -11,14 +13,25 @@ export function useEnvironment(
   fixtureProjectName: string,
   networkName = "localhost"
 ) {
-  beforeEach("Loading hardhat environment", function () {
+  beforeEach("Loading hardhat environment", async function () {
     process.chdir(path.join(__dirname, "fixture-projects", fixtureProjectName));
     process.env.HARDHAT_NETWORK = networkName;
 
     this.env = require("hardhat");
+    this.freePort = await getPortFree();
   });
 
   afterEach("Resetting hardhat", function () {
     resetHardhatContext();
+  });
+}
+
+async function getPortFree() {
+  return new Promise((res) => {
+    const srv = net.createServer() as any;
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close((_err: any) => res(port));
+    });
   });
 }

--- a/packages/hardhat-anvil/test/index.ts
+++ b/packages/hardhat-anvil/test/index.ts
@@ -25,6 +25,7 @@ describe("Anvil plugin with empty configs", function () {
   it("Should run Hardhat TEST task using Anvil", async function () {
     const failures = await this.env.run("test", {
       testFiles: [],
+      port: this.freePort,
     });
 
     assert.equal(failures, 0);
@@ -34,6 +35,7 @@ describe("Anvil plugin with empty configs", function () {
     await this.env.run("run", {
       noCompile: true,
       script: "scripts/accounts-sample.js",
+      port: this.freePort,
     });
 
     assert.equal(process.exitCode, 0);
@@ -43,6 +45,7 @@ describe("Anvil plugin with empty configs", function () {
     await this.env.run("run", {
       noCompile: true,
       script: "scripts/delayed-sample.js",
+      port: this.freePort,
     });
 
     assert.equal(process.exitCode, 0);
@@ -91,7 +94,7 @@ describe("Anvil plugin with custom configs", function () {
   });
 
   it("Should add run anvil node", async function () {
-    void this.env.run("node");
+    void this.env.run("node", { port: this.freePort });
     // ensure we don't wait forever
     await new Promise((resolve) => setTimeout(resolve, 5000));
   });

--- a/packages/hardhat/test/helpers.ts
+++ b/packages/hardhat/test/helpers.ts
@@ -1,6 +1,7 @@
 import { resetHardhatContext } from "hardhat/plugins-testing";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
+import net from "net";
 
 declare module "mocha" {
   interface Context {
@@ -9,13 +10,24 @@ declare module "mocha" {
 }
 
 export function useEnvironment(fixtureProjectName: string) {
-  beforeEach("Loading hardhat environment", function () {
+  beforeEach("Loading hardhat environment", async function () {
     process.chdir(path.join(__dirname, "fixture-projects", fixtureProjectName));
 
     this.hre = require("hardhat");
+    this.freePort = await getPortFree();
   });
 
   afterEach("Resetting hardhat", function () {
     resetHardhatContext();
+  });
+}
+
+async function getPortFree() {
+  return new Promise((res) => {
+    const srv = net.createServer() as any;
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close((_err: any) => res(port));
+    });
   });
 }

--- a/packages/hardhat/test/project.test.ts
+++ b/packages/hardhat/test/project.test.ts
@@ -15,7 +15,7 @@ describe("Integration tests", function () {
     });
 
     it("Should add run anvil node", async function () {
-      void this.hre.run("node");
+      void this.hre.run("node", { port: this.freePort });
       // ensure we don't wait forever
       await new Promise((resolve) => setTimeout(resolve, 5000));
     });
@@ -34,8 +34,8 @@ describe("Integration tests", function () {
       }
     });
 
-    it.only("Should add run anvil node", async function () {
-      void this.hre.run("node");
+    it("Should add run anvil node", async function () {
+      void this.hre.run("node", { port: this.freePort });
       // ensure we don't wait forever
       await new Promise((resolve) => setTimeout(resolve, 5000));
     });


### PR DESCRIPTION
Closes #39 #53

fetch a free port and explicitly set the `port` value when launching anvil