### PR TITLE
feat: better `BuildInfo` support

### DIFF
--- a/.changeset/poor-zebras-allow.md
+++ b/.changeset/poor-zebras-allow.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Better `BuildInfo` support

--- a/packages/hardhat-forge/src/forge/build/build.ts
+++ b/packages/hardhat-forge/src/forge/build/build.ts
@@ -21,6 +21,7 @@ export declare interface ForgeBuildArgs extends CompilerArgs, ProjectPathArgs {
   useSolc?: string;
   offline?: boolean;
   viaIr?: boolean;
+  buildInfo?: boolean;
 }
 
 /** *
@@ -74,6 +75,9 @@ export function buildArgs(args: ForgeBuildArgs): string[] {
   }
   if (args.viaIr === true) {
     allArgs.push("--via-ir");
+  }
+  if (args.buildInfo === true) {
+    allArgs.push("--build-info");
   }
 
   allArgs.push(...compilerArgs(args));

--- a/packages/hardhat-forge/src/forge/config/config.ts
+++ b/packages/hardhat-forge/src/forge/config/config.ts
@@ -63,4 +63,5 @@ export declare interface FoundryConfig {
   bytecode_hash?: string;
   revert_strings?: any;
   sparse_mode?: boolean;
+  build_info?: boolean;
 }

--- a/packages/hardhat-forge/src/forge/types.ts
+++ b/packages/hardhat-forge/src/forge/types.ts
@@ -1,3 +1,5 @@
+import { BuildInfo } from "hardhat/types";
+
 /**
  * Represents an artifact emitted by forge
  */
@@ -46,4 +48,11 @@ export interface FileEntry {
   imports: any[];
   versionRequirement: string;
   artifacts: Map<string, string>;
+}
+
+// Represents a BuildInfo and the path
+// to its file on the filesystem
+export interface BuildInfoArtifact {
+  buildInfo: BuildInfo;
+  buildInfoPath: string;
 }

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -1,11 +1,7 @@
 import { extendEnvironment } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
 import path from "path";
-import {
-  ForgeArtifacts,
-  SOLIDITY_FILES_CACHE_FILENAME,
-  spawnConfigSync,
-} from "./forge";
+import { ForgeArtifacts, spawnConfigSync } from "./forge";
 
 export * from "./task-names";
 export * as forge from "./forge";
@@ -15,19 +11,19 @@ extendEnvironment((hre) => {
   (hre as any).artifacts = lazyObject(() => {
     const config = spawnConfigSync();
     const outDir = path.join(hre.config.paths.root, config.out);
-    const cacheDir = path.join(
-      hre.config.paths.root,
-      config.cache_path ?? "cache",
-      SOLIDITY_FILES_CACHE_FILENAME
-    );
+    // the build info directory is not currently configurable,
+    // it will always be placed in out/build-info
+    const buildInfoDir = path.join(outDir, "build-info");
 
     const artifacts = new ForgeArtifacts(
       hre.config.paths.root,
       outDir,
-      cacheDir
+      hre.config.paths.artifacts,
+      buildInfoDir,
+      config.build_info
     );
 
-    artifacts.writeArtifactsSync(hre.config.paths.artifacts);
+    artifacts.writeArtifactsSync();
     return artifacts;
   });
 });

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
@@ -4,5 +4,6 @@ out = 'out'
 libs = ['lib']
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
+build_info = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -40,13 +40,27 @@ describe("Integration tests", function () {
     it("Should write artifacts to disk", async function () {
       const artifacts = await this.hre.artifacts.getArtifactPaths();
       const files = await getAllFiles(this.hre.config.paths.artifacts);
-      assert.equal(artifacts.length, files.length);
+      // filter out the debug files
+      const filtered = files.filter((f) => !f.includes(".dbg.json"));
+      assert.equal(artifacts.length, filtered.length);
 
-      for (const file of files) {
+      for (const file of filtered) {
         const name = path.basename(file);
         assert(artifacts.map((a) => path.basename(a)).includes(name));
         const artifact = require(file);
         assert.equal(artifact.contractName, path.basename(name, ".json"));
+      }
+    });
+
+    it("Should write debug files to disk", async function () {
+      const debugFilePaths = await this.hre.artifacts.getDebugFilePaths();
+      const artifactPaths = await this.hre.artifacts.getArtifactPaths();
+      assert.equal(debugFilePaths.length, artifactPaths.length);
+
+      for (const debugFile of debugFilePaths) {
+        const debug = require(debugFile);
+        assert.equal(debug._format, "hh-sol-dbg-1");
+        assert.exists(debug.buildInfo);
       }
     });
 


### PR DESCRIPTION
This PR is a companion to https://github.com/foundry-rs/foundry/pull/2012

It adds better support for `hre.artifacts.getBuildInfo`. The hardhat plugin doesn't currently have access to the values that make up the hash for the filename, so it simply searches through each `BuildInfo` to find the correct one. Not super ideal, but works for now.

It will generate the debug files in the same way that hardhat does, so hardhat plugins that rely on the debug files should just work.

To be able to optimize this, the hardhat plugin needs to be able to compute `md5(_format,solcVersion,solcLongVersion,input)`