### PR TITLE
feat(hardhat-forge): add `foundry` config section

### DIFF
--- a/.changeset/breezy-walls-greet.md
+++ b/.changeset/breezy-walls-greet.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add `foundry` section to hardhat config

--- a/packages/hardhat-forge/src/forge/build/index.ts
+++ b/packages/hardhat-forge/src/forge/build/index.ts
@@ -14,8 +14,9 @@ registerProjectPathArgs(registerCompilerArgs(task("compile")))
     "viaIr",
     "Use the Yul intermediate representation compilation pipeline."
   )
-  .setAction(async (args, {}, runSuper) => {
-    const buildArgs = await getCheckedArgs(args);
+  .setAction(async (args, hre, runSuper) => {
+    const input = { ...args, ...(hre.config.foundry || {}) };
+    const buildArgs = await getCheckedArgs(input);
     await spawnBuild(buildArgs);
     await runSuper(args);
   });

--- a/packages/hardhat-forge/src/forge/types.ts
+++ b/packages/hardhat-forge/src/forge/types.ts
@@ -1,4 +1,21 @@
+import "hardhat/types/config";
 import { BuildInfo } from "hardhat/types";
+import { ForgeEvmArgs } from "./common/evm";
+import { ForgeBuildArgs } from "./build/build";
+
+export interface FoundryHardhatConfig
+  extends Partial<ForgeEvmArgs>,
+    Partial<ForgeBuildArgs> {}
+
+declare module "hardhat/types/config" {
+  interface HardhatConfig {
+    foundry?: Partial<FoundryHardhatConfig>;
+  }
+
+  interface HardhatUserConfig {
+    foundry?: Partial<FoundryHardhatConfig>;
+  }
+}
 
 /**
  * Represents an artifact emitted by forge

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -1,12 +1,14 @@
-import { extendEnvironment } from "hardhat/config";
+import "./forge/types";
+import { extendEnvironment, extendConfig } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
+import { HardhatConfig, HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
 import { ForgeArtifacts, spawnConfigSync } from "./forge";
 
 export * from "./task-names";
 export * as forge from "./forge";
 
-extendEnvironment((hre) => {
+extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   // patches the default artifacts handler
   (hre as any).artifacts = lazyObject(() => {
     const config = spawnConfigSync();
@@ -26,4 +28,8 @@ extendEnvironment((hre) => {
     artifacts.writeArtifactsSync();
     return artifacts;
   });
+});
+
+extendConfig((config: HardhatConfig) => {
+  config.foundry = config.foundry || {};
 });

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -5,7 +5,8 @@ import "../../../src/index";
 
 const config: HardhatUserConfig = {
   solidity: "0.7.3",
-  defaultNetwork: "hardhat"
+  defaultNetwork: "hardhat",
+  foundry: {},
 };
 
 export default config;

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -21,6 +21,11 @@ describe("Integration tests", function () {
       assert.equal(config.out, "out");
     });
 
+    it("Should populare hre.config.foundry", async function () {
+      assert.exists(this.hre.config.foundry);
+      assert.typeOf(this.hre.config.foundry, "object");
+    });
+
     it("Should read artifacts", async function () {
       const artifacts = await this.hre.artifacts.getArtifactPaths();
       assert.isNotEmpty(artifacts);


### PR DESCRIPTION
The `hardhat.config.ts` now can have a `foundry` section that
allows users to place config values in. This makes it so that
expensive operations like generating the build info can be placed
in the `hardhat.config.ts` and not in the `foundry.toml` so that
`forge build` can be ligher than `hardhat compile`.