### PR TITLE
feat(hardhat-forge): add `foundry` config section

### DIFF
--- a/.changeset/hip-pears-crash.md
+++ b/.changeset/hip-pears-crash.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Fix hh style foundry config

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -1,7 +1,11 @@
 import "./forge/types";
 import { extendEnvironment, extendConfig } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
-import { HardhatConfig, HardhatRuntimeEnvironment } from "hardhat/types";
+import {
+  HardhatConfig,
+  HardhatUserConfig,
+  HardhatRuntimeEnvironment,
+} from "hardhat/types";
 import path from "path";
 import { ForgeArtifacts, spawnConfigSync } from "./forge";
 
@@ -30,6 +34,8 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   });
 });
 
-extendConfig((config: HardhatConfig) => {
-  config.foundry = config.foundry || {};
-});
+extendConfig(
+  (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
+    config.foundry = userConfig.foundry || {};
+  }
+);

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -6,7 +6,9 @@ import "../../../src/index";
 const config: HardhatUserConfig = {
   solidity: "0.7.3",
   defaultNetwork: "hardhat",
-  foundry: {},
+  foundry: {
+    viaIr: true
+  },
 };
 
 export default config;

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -24,6 +24,7 @@ describe("Integration tests", function () {
     it("Should populare hre.config.foundry", async function () {
       assert.exists(this.hre.config.foundry);
       assert.typeOf(this.hre.config.foundry, "object");
+      assert.equal(this.hre.config.foundry?.viaIr, true);
     });
 
     it("Should read artifacts", async function () {


### PR DESCRIPTION
The `hardhat.config.ts` now can have a `foundry` section that
allows users to place config values in. This makes it so that
expensive operations like generating the build info can be placed
in the `hardhat.config.ts` and not in the `foundry.toml` so that
`forge build` can be ligher than `hardhat compile`.