### PR TITLE
fix: make foundry config a lazy object

### DIFF
--- a/.changeset/sweet-wasps-share.md
+++ b/.changeset/sweet-wasps-share.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Make foundry config lazy

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -36,6 +36,8 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
 
 extendConfig(
   (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
-    config.foundry = userConfig.foundry || {};
+    config.foundry = lazyObject(() => {
+      return userConfig.foundry || {};
+    });
   }
 );


### PR DESCRIPTION
Was experiencing hardhat oom'ing, the hh docs
recommend using `lazyObject` when building plugins
that modify the `hre` of the `HardhatConfig` objects.