### PR TITLE
feat: configurable runSuper (#73)

### DIFF
--- a/.changeset/popular-humans-greet.md
+++ b/.changeset/popular-humans-greet.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Allow user configured `runSuper` to be called in the build task

--- a/packages/hardhat-forge/src/forge/build/index.ts
+++ b/packages/hardhat-forge/src/forge/build/index.ts
@@ -18,7 +18,9 @@ registerProjectPathArgs(registerCompilerArgs(task("compile")))
     const input = { ...args, ...(hre.config.foundry || {}) };
     const buildArgs = await getCheckedArgs(input);
     await spawnBuild(buildArgs);
-    await runSuper(args);
+    if (hre.config.foundry?.runSuper!) {
+      await runSuper(args);
+    }
   });
 
 async function getCheckedArgs(args: any): Promise<ForgeBuildArgs> {

--- a/packages/hardhat-forge/src/forge/types.ts
+++ b/packages/hardhat-forge/src/forge/types.ts
@@ -5,7 +5,9 @@ import { ForgeBuildArgs } from "./build/build";
 
 export interface FoundryHardhatConfig
   extends Partial<ForgeEvmArgs>,
-    Partial<ForgeBuildArgs> {}
+    Partial<ForgeBuildArgs> {
+  runSuper?: boolean;
+}
 
 declare module "hardhat/types/config" {
   interface HardhatConfig {

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -37,7 +37,11 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
 extendConfig(
   (config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) => {
     config.foundry = lazyObject(() => {
-      return userConfig.foundry || {};
+      // Set default values then merge user defined values
+      return {
+        runSuper: false,
+        ...userConfig.foundry,
+      };
     });
   }
 );


### PR DESCRIPTION
Starts the release process by merging develop into master. After merge, we should base the changesets PR that gets opened automatically on develop then merge and merge develop into master again to finally trigger the release

---

Allow the user to configure `runSuper` in the
build task. Allowing the user to run this will
allow for more composability with other hardhat
based tooling but will slow down the build.

It was previously defaulted to true, but I found
in practice that its generally not necessary to
be true for just compilation. Things like `typechain`
will not automatically run afterwards, but `typechain`
doesn't currently work exactly the same as the foundry
`Artifacts` doesn't have the concept of `validArtifacts`
populated after building. We run `typechain` on its own
after compilation to get around this difference, so
always calling `runSuper` just slows down the build.