### PR TITLE
feat(hardhat-forge): allow skipping of tests

### DIFF
--- a/.changeset/angry-walls-film.md
+++ b/.changeset/angry-walls-film.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add config for skipping the compilation of tests

--- a/packages/hardhat-forge/src/forge/build/index.ts
+++ b/packages/hardhat-forge/src/forge/build/index.ts
@@ -1,8 +1,22 @@
-import { task } from "hardhat/config";
+import { task, subtask } from "hardhat/config";
+import { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } from "hardhat/builtin-tasks/task-names";
 import camelcaseKeys = require("camelcase-keys");
 import { NomicLabsHardhatPluginError } from "hardhat/internal/core/errors";
 import { registerCompilerArgs, registerProjectPathArgs } from "../common";
 import { ForgeBuildArgs, spawnBuild } from "./build";
+
+// Allow the user to skip compiling tests if the `skipTests` config
+// is set in the foundry config. This speeds up compilation time by a lot.
+subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
+  async (_, hre, runSuper) => {
+    const paths = await runSuper();
+
+    if (hre.config.foundry?.skipTests!) {
+      return paths.filter((p: string) => !p.endsWith(".t.sol"));
+    }
+    return paths;
+  }
+);
 
 registerProjectPathArgs(registerCompilerArgs(task("compile")))
   .setDescription("Compiles the entire project with forge")

--- a/packages/hardhat-forge/src/forge/types.ts
+++ b/packages/hardhat-forge/src/forge/types.ts
@@ -7,6 +7,7 @@ export interface FoundryHardhatConfig
   extends Partial<ForgeEvmArgs>,
     Partial<ForgeBuildArgs> {
   runSuper?: boolean;
+  skipTests?: boolean;
 }
 
 declare module "hardhat/types/config" {


### PR DESCRIPTION
Add a new config option that allows users to skip
compilation of their tests. A test is defined
as a file that ends with a `.t.sol` extension.
This speeds up compilation quite a bit in the
optimism codebase, as compiling the tests
is the slowest part of the compilation pipeline.

If a user specifies the following in the `hardhat.config.ts`:

```js
  foundry: {
    skipTests: true
  }
```

Then the tests will not be compiled