### PR TITLE
hardhat-forge: configurable artifact output

### DIFF
--- a/.changeset/seven-bees-itch.md
+++ b/.changeset/seven-bees-itch.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add config for writing artifacts to allow conditional writing of artifacts

--- a/packages/hardhat-forge/package.json
+++ b/packages/hardhat-forge/package.json
@@ -23,7 +23,7 @@
     "prettier": "prettier \"**/*.{js,md}\"",
     "test": "mocha --recursive \"test/**/*.ts\" --exit",
     "build": "tsc --build .",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist test/fixture-projects/hardhat-project/{artifacts,cache,out}"
   },
   "files": [
     "dist/",

--- a/packages/hardhat-forge/src/forge/build/index.ts
+++ b/packages/hardhat-forge/src/forge/build/index.ts
@@ -18,6 +18,11 @@ registerProjectPathArgs(registerCompilerArgs(task("compile")))
     const input = { ...args, ...(hre.config.foundry || {}) };
     const buildArgs = await getCheckedArgs(input);
     await spawnBuild(buildArgs);
+
+    if (hre.config.foundry?.writeArtifacts!) {
+      (hre as any).artifacts.writeArtifactsSync();
+    }
+
     if (hre.config.foundry?.runSuper!) {
       await runSuper(args);
     }

--- a/packages/hardhat-forge/src/forge/types.ts
+++ b/packages/hardhat-forge/src/forge/types.ts
@@ -7,6 +7,7 @@ export interface FoundryHardhatConfig
   extends Partial<ForgeEvmArgs>,
     Partial<ForgeBuildArgs> {
   runSuper?: boolean;
+  writeArtifacts?: boolean;
 }
 
 declare module "hardhat/types/config" {

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -29,7 +29,6 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
       config.build_info
     );
 
-    artifacts.writeArtifactsSync();
     return artifacts;
   });
 });
@@ -40,6 +39,7 @@ extendConfig(
       // Set default values then merge user defined values
       return {
         runSuper: false,
+        writeArtifacts: true,
         ...userConfig.foundry,
       };
     });

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -7,7 +7,8 @@ const config: HardhatUserConfig = {
   solidity: "0.7.3",
   defaultNetwork: "hardhat",
   foundry: {
-    viaIr: true
+    viaIr: true,
+    writeArtifacts: true,
   },
 };
 


### PR DESCRIPTION
Add an additional config option to the hardhat config
that allows a user to disable writing the hardhat artifacts.
It defaults to true.

The config option looks like:

```js
const config: HardhatUserConfig = {
  foundry: {
    writeArtifacts: true,
  },
}
```

This PR ensures that the artifacts are actually written to disk, because wrapping the `hre.Artifacts` in a `lazyObject` means that that the code will not execute unless `hre.Artifacts` is referenced someplace in the codebase. This means that if something doesn't touch `hre.Artifacts`, they will not be written to disk. This moves the logic of writing to disk outside of the creation of `hre.Artifacts` and puts it behind a config flag so that users can disable the functionality if they desire.