### PR TITLE
hardhat-forge: parse string metadata

### DIFF
--- a/.changeset/lazy-news-hide.md
+++ b/.changeset/lazy-news-hide.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Deserialize compiler output metadata in buildinfo

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -143,6 +143,16 @@ export class ForgeArtifacts implements IArtifacts {
     }
 
     const buildInfo = fsExtra.readJsonSync(buildInfoPath) as BuildInfo;
+
+    // Handle ethers-solc serializing the metadata as a string
+    // when hardhat serializes it as an object
+    for (const contract of Object.values(buildInfo.output.contracts)) {
+      for (const output of Object.values(contract)) {
+        if (typeof (output as any).metadata === "string") {
+          (output as any).metadata = JSON.parse((output as any).metadata);
+        }
+      }
+    }
     return buildInfo;
   }
 

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -78,6 +78,7 @@ describe("Integration tests", function () {
       assert.exists(contract.abi);
       assert.exists((contract as any).devdoc);
       assert.exists((contract as any).metadata);
+      assert.typeOf((contract as any).metadata, "object");
       assert.exists((contract as any).storageLayout);
       assert.exists((contract as any).userdoc);
       assert.exists(contract.evm);


### PR DESCRIPTION
The build info compiler output metadata is serialized as a string and hardhat tooling that reads these files expects the string to be an object. This PR looks to see if the metadata is a string and then parses the json string into an object.

The first commit includes a failing test to show that this is a problem.

Perhaps another way to fix this would be to serialize the metadata as a json object in ethers-solc.
