### PR TITLE
feat(hardhat-forge): build info path config (#84)

### DIFF
--- a/.changeset/late-rivers-applaud.md
+++ b/.changeset/late-rivers-applaud.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add build_info_path config

--- a/packages/hardhat-forge/src/forge/build/build.ts
+++ b/packages/hardhat-forge/src/forge/build/build.ts
@@ -22,6 +22,7 @@ export declare interface ForgeBuildArgs extends CompilerArgs, ProjectPathArgs {
   offline?: boolean;
   viaIr?: boolean;
   buildInfo?: boolean;
+  buildInfoPath?: string;
 }
 
 /** *
@@ -78,6 +79,9 @@ export function buildArgs(args: ForgeBuildArgs): string[] {
   }
   if (args.buildInfo === true) {
     allArgs.push("--build-info");
+  }
+  if (typeof args.buildInfoPath === "string") {
+    allArgs.push("--build-info-path", args.buildInfoPath);
   }
 
   allArgs.push(...compilerArgs(args));

--- a/packages/hardhat-forge/src/forge/config/config.ts
+++ b/packages/hardhat-forge/src/forge/config/config.ts
@@ -64,4 +64,5 @@ export declare interface FoundryConfig {
   revert_strings?: any;
   sparse_mode?: boolean;
   build_info?: boolean;
+  build_info_path?: string;
 }

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -17,9 +17,10 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   (hre as any).artifacts = lazyObject(() => {
     const config = spawnConfigSync();
     const outDir = path.join(hre.config.paths.root, config.out);
-    // the build info directory is not currently configurable,
-    // it will always be placed in out/build-info
-    const buildInfoDir = path.join(outDir, "build-info");
+    const buildInfoDir =
+      typeof config.build_info_path === "string"
+        ? config.build_info_path
+        : path.join(outDir, "build-info");
 
     const artifacts = new ForgeArtifacts(
       hre.config.paths.root,

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
@@ -5,5 +5,6 @@ libs = ['lib']
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 build_info = true
+build_info_path = 'build-info'
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Merging develop into master to start the release process

---
Allow the `build_info_path` config option to be parsed
and passed through the hardhat plugin. It will correctly
create the debug files that point to the build info files
dynamically based on the configured build info path.

The tests that fetch the build info objects still pass, they
look up the path from the debug file to the build info file.