### PR TITLE
fix: rebase develop on master

### DIFF
--- a/.changeset/late-rivers-applaud.md
+++ b/.changeset/late-rivers-applaud.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Add build_info_path config

--- a/.changeset/late-rivers-applaud.md
+++ b/.changeset/late-rivers-applaud.md
@@ -1,5 +1,0 @@
----
-"@foundry-rs/hardhat-forge": patch
----
-
-Add build_info_path config

--- a/.changeset/lazy-news-hide.md
+++ b/.changeset/lazy-news-hide.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Deserialize compiler output metadata in buildinfo

--- a/packages/hardhat-forge/CHANGELOG.md
+++ b/packages/hardhat-forge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @foundry-rs/hardhat-forge
 
+## 0.1.13
+
+### Patch Changes
+
+- 8fe943c: Add build_info_path config
+
 ## 0.1.12
 
 ### Patch Changes

--- a/packages/hardhat-forge/package.json
+++ b/packages/hardhat-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foundry-rs/hardhat-forge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Hardhat plugin for foundry's forge",
   "homepage": "https://github.com/foundry-rs/hardhat",
   "repository": "github:foundry-rs/hardhat",

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -143,6 +143,16 @@ export class ForgeArtifacts implements IArtifacts {
     }
 
     const buildInfo = fsExtra.readJsonSync(buildInfoPath) as BuildInfo;
+
+    // Handle ethers-solc serializing the metadata as a string
+    // when hardhat serializes it as an object
+    for (const contract of Object.values(buildInfo.output.contracts)) {
+      for (const output of Object.values(contract)) {
+        if (typeof (output as any).metadata === "string") {
+          (output as any).metadata = JSON.parse((output as any).metadata);
+        }
+      }
+    }
     return buildInfo;
   }
 

--- a/packages/hardhat-forge/src/forge/build/build.ts
+++ b/packages/hardhat-forge/src/forge/build/build.ts
@@ -22,6 +22,7 @@ export declare interface ForgeBuildArgs extends CompilerArgs, ProjectPathArgs {
   offline?: boolean;
   viaIr?: boolean;
   buildInfo?: boolean;
+  buildInfoPath?: string;
 }
 
 /** *
@@ -78,6 +79,9 @@ export function buildArgs(args: ForgeBuildArgs): string[] {
   }
   if (args.buildInfo === true) {
     allArgs.push("--build-info");
+  }
+  if (typeof args.buildInfoPath === "string") {
+    allArgs.push("--build-info-path", args.buildInfoPath);
   }
 
   allArgs.push(...compilerArgs(args));

--- a/packages/hardhat-forge/src/forge/config/config.ts
+++ b/packages/hardhat-forge/src/forge/config/config.ts
@@ -64,4 +64,5 @@ export declare interface FoundryConfig {
   revert_strings?: any;
   sparse_mode?: boolean;
   build_info?: boolean;
+  build_info_path?: string;
 }

--- a/packages/hardhat-forge/src/index.ts
+++ b/packages/hardhat-forge/src/index.ts
@@ -17,9 +17,10 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
   (hre as any).artifacts = lazyObject(() => {
     const config = spawnConfigSync();
     const outDir = path.join(hre.config.paths.root, config.out);
-    // the build info directory is not currently configurable,
-    // it will always be placed in out/build-info
-    const buildInfoDir = path.join(outDir, "build-info");
+    const buildInfoDir =
+      typeof config.build_info_path === "string"
+        ? config.build_info_path
+        : path.join(outDir, "build-info");
 
     const artifacts = new ForgeArtifacts(
       hre.config.paths.root,

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
@@ -5,5 +5,6 @@ libs = ['lib']
 
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 build_info = true
+build_info_path = 'build-info'
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -78,6 +78,7 @@ describe("Integration tests", function () {
       assert.exists(contract.abi);
       assert.exists((contract as any).devdoc);
       assert.exists((contract as any).metadata);
+      assert.typeOf((contract as any).metadata, "object");
       assert.exists((contract as any).storageLayout);
       assert.exists((contract as any).userdoc);
       assert.exists(contract.evm);


### PR DESCRIPTION
Rebases develop on master so that the 2 branches do not diverge. Will follow up with a release PR after this one

Fixes https://github.com/foundry-rs/hardhat/pull/87 being merged directly into master instead of first being merged into develop and then develop being merged into master