### PR TITLE
hardhat-forge: multiple contracts same name

### DIFF
--- a/.changeset/real-beds-enjoy.md
+++ b/.changeset/real-beds-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Handle writing artifacts when multiple contracts have the same name

--- a/packages/hardhat-forge/.gitignore
+++ b/packages/hardhat-forge/.gitignore
@@ -5,3 +5,4 @@ build/
 artifacts/
 cache/
 !src/forge/build
+build-info

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -94,6 +94,11 @@ export class ForgeArtifacts implements IArtifacts {
       throw new Error("Must compile with ast");
     }
 
+    if (isFullyQualifiedName(name)) {
+      const { contractName } = parseFullyQualifiedName(name);
+      name = contractName;
+    }
+
     const hhArtifact = {
       _format: ARTIFACT_FORMAT_VERSION,
       contractName: name,
@@ -572,7 +577,9 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     const paths = this._getArtifactPathsSync();
 
     for (const filepath of paths) {
-      const artifact = this.readArtifactSync(path.parse(filepath).name);
+      // Handle multiple contracts with the same name
+      const fqn = this._getFullyQualifiedNameFromPath(filepath);
+      const artifact = this.readArtifactSync(fqn);
       const out = this._getHardhatArtifactPathFromForgePath(filepath);
       fsExtra.mkdirpSync(path.dirname(out));
       fsExtra.writeJsonSync(out, artifact, { spaces: 2 });

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']
@@ -6,5 +6,3 @@ libs = ['lib']
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 build_info = true
 build_info_path = 'build-info'
-
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/foo/Contract2.sol
+++ b/packages/hardhat-forge/test/fixture-projects/hardhat-project/src/foo/Contract2.sol
@@ -1,8 +1,7 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-contract FooBar {
-
+contract Contract {
   function example() public {}
 
 }

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -30,7 +30,9 @@ describe("Integration tests", function () {
     it("Should read artifacts", async function () {
       const artifacts = await this.hre.artifacts.getArtifactPaths();
       assert.isNotEmpty(artifacts);
-      const contract = await this.hre.artifacts.readArtifact("Contract");
+      const contract = await this.hre.artifacts.readArtifact(
+        "Contract.sol:Contract"
+      );
       assert.equal(contract.sourceName, "src/Contract.sol");
       assert.exists(contract.abi);
       assert.exists(contract.bytecode);
@@ -71,7 +73,9 @@ describe("Integration tests", function () {
     });
 
     it("Should return build info", async function () {
-      const info = await this.hre.artifacts.getBuildInfo("Contract");
+      const info = await this.hre.artifacts.getBuildInfo(
+        "Contract.sol:Contract"
+      );
       assert.exists(info);
       const contract = info?.output.contracts["src/Contract.sol"].Contract!;
       assert.exists(contract);


### PR DESCRIPTION
Properly handle building artifacts when multiple contracts
have the same name. Previously this would fail as fully qualified
names were not being used and it would become ambiguous which
contract was being referenced. Now paths are converted into
fully qualified names such that it is no longer ambiguous what
contract is being referenced.