### PR TITLE
hardhat-forge: handle case insensitive filesystem

### DIFF
--- a/.changeset/cold-ways-refuse.md
+++ b/.changeset/cold-ways-refuse.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Handle case insensitivity in filesystem

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -299,13 +299,25 @@ export class ForgeArtifacts implements IArtifacts {
     const artifactPath =
       this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
-    const trueCaseArtifactPath = await this._trueCasePath(
+    let trueCaseArtifactPath = await this._trueCasePath(
       path.relative(this._out, artifactPath),
       this._out
     );
 
+    // On case-sensitive filesystems, "true-case-path"
+    // contains a bug that results in it only observing
+    // one of the many possible matching files but with different
+    // casings. If this bug is encountered, check to see if the
+    // artifact path exists on the filesystem and if it does then
+    // we know that the casing is not a problem.
     if (trueCaseArtifactPath === null) {
-      return this._handleWrongArtifactForFullyQualifiedName(fullyQualifiedName);
+      if (await fsExtra.pathExists(artifactPath)) {
+        trueCaseArtifactPath = artifactPath;
+      } else {
+        return this._handleWrongArtifactForFullyQualifiedName(
+          fullyQualifiedName
+        );
+      }
     }
 
     if (artifactPath !== trueCaseArtifactPath) {
@@ -472,13 +484,19 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     const artifactPath =
       this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
-    const trueCaseArtifactPath = this._trueCasePathSync(
+    let trueCaseArtifactPath = this._trueCasePathSync(
       path.relative(this._out, artifactPath),
       this._out
     );
 
     if (trueCaseArtifactPath === null) {
-      return this._handleWrongArtifactForFullyQualifiedName(fullyQualifiedName);
+      if (fsExtra.pathExistsSync(artifactPath)) {
+        trueCaseArtifactPath = artifactPath;
+      } else {
+        return this._handleWrongArtifactForFullyQualifiedName(
+          fullyQualifiedName
+        );
+      }
     }
 
     if (artifactPath !== trueCaseArtifactPath) {


### PR DESCRIPTION
The artifact paths and filenames are based on the names
of the files containing the smart contracts and the names of
the contracts inside of the files.

The npm package `true-case-path` has a bug that causes it to
ignore directories that are spelled the same but have alternate
casing.

You can see here that it eagerly returns if the case insensitive
regex hits:
https://github.com/Profiscience/true-case-path/blob/8a016e6a8be64c873aba414fbcdb4748e24dc796/index.js#L31

The problem is that it could hit multiple files and we need to check
each, not just the first one that it hits.

The problem is with `DSTest` and `forge-std`, where `DSTest` has
a `test.sol` and `forge-std` has a `Test.sol`. The regex hits
incorrectly and downstream consumers get passed the wrong data.

The fix simply looks to see if `true-case-path` has an error
(returns `null`) and then uses `fsExtra` to look directly at the
filesystem. If directly looking at the filesystem works, then
we know that the file is there and don't need to error.