### PR TITLE
hardhat-forge: ignore metadata files

### DIFF
--- a/.changeset/weak-masks-change.md
+++ b/.changeset/weak-masks-change.md
@@ -1,0 +1,5 @@
+---
+"@foundry-rs/hardhat-forge": patch
+---
+
+Ignore metadata files when getting contract artifacts

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -165,7 +165,7 @@ export class ForgeArtifacts implements IArtifacts {
     const paths = await glob(path.join(this._out, "**/*.json"), {
       ignore: path.join(this._buildInfo, "*.json"),
     });
-    return paths.filter(p => !p.endsWith(".metadata.json")).sort();
+    return paths.filter((p) => !p.endsWith(".metadata.json")).sort();
   }
 
   public async getBuildInfoPaths(): Promise<string[]> {
@@ -218,7 +218,7 @@ export class ForgeArtifacts implements IArtifacts {
     const paths = globSync(path.join(this._out, "**/*.json"), {
       ignore: path.join(this._buildInfo, "*.json"),
     });
-    return paths.filter(p => !p.endsWith(".metadata.json")).sort();
+    return paths.filter((p) => !p.endsWith(".metadata.json")).sort();
   }
 
   /**

--- a/packages/hardhat-forge/src/forge/artifacts.ts
+++ b/packages/hardhat-forge/src/forge/artifacts.ts
@@ -165,7 +165,7 @@ export class ForgeArtifacts implements IArtifacts {
     const paths = await glob(path.join(this._out, "**/*.json"), {
       ignore: path.join(this._buildInfo, "*.json"),
     });
-    return paths.sort();
+    return paths.filter(p => !p.endsWith(".metadata.json")).sort();
   }
 
   public async getBuildInfoPaths(): Promise<string[]> {
@@ -218,7 +218,7 @@ export class ForgeArtifacts implements IArtifacts {
     const paths = globSync(path.join(this._out, "**/*.json"), {
       ignore: path.join(this._buildInfo, "*.json"),
     });
-    return paths.sort();
+    return paths.filter(p => !p.endsWith(".metadata.json")).sort();
   }
 
   /**

--- a/packages/hardhat-forge/test/project.test.ts
+++ b/packages/hardhat-forge/test/project.test.ts
@@ -48,8 +48,10 @@ describe("Integration tests", function () {
     it("Should write artifacts to disk", async function () {
       const artifacts = await this.hre.artifacts.getArtifactPaths();
       const files = await getAllFiles(this.hre.config.paths.artifacts);
-      // filter out the debug files
-      const filtered = files.filter((f) => !f.includes(".dbg.json"));
+      // filter out the debug files and metadata
+      const filtered = files
+        .filter((f) => !f.includes(".dbg.json"))
+        .filter((f) => !f.includes(".metadata.json"));
       assert.equal(artifacts.length, filtered.length);
 
       for (const file of filtered) {


### PR DESCRIPTION
When getting contract artifacts, json files are pulled out of
the artifacts directory. Since metadata files are now emitted by
default as of
https://github.com/foundry-rs/foundry/commit/ad91a4a962ddf2f3c3e340c018482851a5080f01,
extra files were being passed through the hh artifact generation
pipeline which broke things because the hardhat artifacts need
the fully qualified name which is currently pulled from the
ast in the compiler out. It could be possible to brute force
the fully qualified name but that would fail when 2 contracts
have a matching name. This filters out the metadata files
when getting the contract artifacts.

This fixes our broken CI