### PR TITLE
Fix forkUrl option handling

### DIFF
--- a/.changeset/thick-hats-unite.md
+++ b/.changeset/thick-hats-unite.md
@@ -1,0 +1,6 @@
+---
+"@foundry-rs/hardhat-anvil": patch
+"@foundry-rs/hardhat": patch
+---
+
+Fix forkUrl option handling

--- a/packages/hardhat-anvil/src/anvil-server.ts
+++ b/packages/hardhat-anvil/src/anvil-server.ts
@@ -55,8 +55,8 @@ export class AnvilServer {
       if (options.chainId) {
         args.push("--chain-id", options.chainId);
       }
-      if (options.forkurl) {
-        args.push("--fork-url", options.forkurl);
+      if (options.forkUrl) {
+        args.push("--fork-url", options.forkUrl);
         if (options.forkBlockNumber) {
           args.push("--fork-block-number", options.forkBlockNumber);
         }


### PR DESCRIPTION
There is a bug in anvil-server, it's expecting option named `forkurl` but the option is capitalized `forkUrl`